### PR TITLE
Update pipewire configuration

### DIFF
--- a/src/bin/fedora/09-pipewire.sh
+++ b/src/bin/fedora/09-pipewire.sh
@@ -6,9 +6,9 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 PIPEWIRE_CONF_DIR="${HOME}/.config/pipewire/"
 
 mkdir -p "${PIPEWIRE_CONF_DIR}"
-cp -R "${SCRIPT_DIR}/../../etc/pipewire/pipewire-pulse.conf.d" \
+cp -R "${SCRIPT_DIR}/../../etc/pipewire/pipewire-pulse.conf.d"/* \
     "${PIPEWIRE_CONF_DIR}/pipewire-pulse.conf.d"
-cp -R "${SCRIPT_DIR}/../../etc/pipewire/pipewire.conf.d" \
+cp -R "${SCRIPT_DIR}/../../etc/pipewire/pipewire.conf.d"/* \
     "${PIPEWIRE_CONF_DIR}/pipewire.conf.d"
 
 systemctl daemon-reload --user

--- a/src/bin/linux/10-rnnoise.sh
+++ b/src/bin/linux/10-rnnoise.sh
@@ -24,3 +24,7 @@ RNNOISE_PATH="/opt/linux-rnnoise"
     rm -f linux-rnnoise.zip
     rm -rf "${TMP_PATH}"
 )
+
+# Create symlink for pipewire 1.6.x
+# https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/8fd798208777f502a3bd86b02b07a24397792f3f
+sudo ln -s "${RNNOISE_PATH}/ladspa/librnnoise_ladspa.so" "/usr/lib64/ladspa/librnnoise_ladspa.so"

--- a/src/etc/pipewire/pipewire.conf.d/99-input-denoising.conf
+++ b/src/etc/pipewire/pipewire.conf.d/99-input-denoising.conf
@@ -8,7 +8,7 @@ context.modules = [
                 {
                     type = ladspa
                     name = rnnoise
-                    plugin = /opt/linux-rnnoise/ladspa/librnnoise_ladspa.so
+                    plugin = librnnoise_ladspa
                     label = noise_suppressor_stereo
                     control = {
                         "VAD Threshold (%)" = 95.0


### PR DESCRIPTION
- Pipewire plugins no longer allow arbitrary paths. Create a symlink from the installation directory to the ladpa plugin directory to resolve this
- Fix config file copy to work as intended